### PR TITLE
Add ClipMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A list of awesome Twitch/streaming-related tools.
  - [Chatterino 7TV](https://github.com/SevenTV/chatterino7) - Chatterino with extra 7TV features. [🌎]
  - [Chatterino](https://chatterino.com) - A mutli-platform Twitch chat client. [🌎]
  - [Chatty](https://chatty.github.io) - A chat software specifically made for Twitch, running on any OS supporting Java 8 or later. [🌎]
+ - [ClipMe](https://clipme.com) - AI clip maker for live streams — turns Twitch, Kick and YouTube streams and VODs into captioned vertical shorts, ranking moments by chat activity. [🆓/💸]
  - [Collaborative Overlay](https://luscious.dev/overlay/) - Collaborative Overlays are a tool for live streamers to give some control over their stream to trusted individuals. [🆓]
  - [Cord.DJ](https://cord.dj/) - Listen to music with friends together. [🆓]
  - [DankChat](https://github.com/flex3r/DankChat/#-dankchat) - A chat client for Android. [🌎🆓]


### PR DESCRIPTION
Adds [ClipMe](https://clipme.com) — an AI clip maker for live streams. Ingests Twitch, Kick and YouTube streams and VODs, ranks moments using signals including chat activity, and renders captioned vertical shorts.

Placed alphabetically in the ungrouped list, tagged [🆓/💸] (free tier + paid plans), matching the existing entry format.

Disclosure: I work on ClipMe.